### PR TITLE
Minor changes

### DIFF
--- a/scripts/download_synthetic_visualcorres_data.py
+++ b/scripts/download_synthetic_visualcorres_data.py
@@ -1,64 +1,89 @@
+"""Convert Synthetic-Visual-Correspondence-Data parquet shards into LLaVA-style JSON + JPEGs.
+
+This script:
+  1) Loads the synthetic visual correspondence dataset from its parquet files.
+  2) Saves paired reference/candidate images to disk as JPEGs.
+  3) Builds LLaVA-style instruction data where the human turn contains two image
+     tokens plus a multiple-choice question (A–D), and the assistant turn is the
+     ground-truth option letter from `ref_label`.
+The resulting JSON file can be used for finetuning or evaluation-style prompts.
+"""
+
 import os
 import json
-from datasets import load_dataset, Features, Image, Value
-from llava.conversation import conv_templates
-from llava.constants import IMAGE_TOKEN_INDEX, DEFAULT_IMAGE_TOKEN
+import argparse
+from datasets import load_dataset
+from llava.constants import DEFAULT_IMAGE_TOKEN
 from tqdm import tqdm
 
-# Define features
-features = Features({
-    'image_1': Image(),      # Reference image
-    'image_2': Image(),      # Candidate image with 4 points (A-D)
-    'id': Value('string'),
-    'source': Value('string'),
-    'labels_dict': Value('string'),  # JSON: positions of A, B, C, D in image_2
-    'ref_label': Value('string'),     # Ground truth: which label (A-D) is correct
-    'ref_label_pos': Value('string'), # JSON: position of reference point in image_1
-})
 
-# Load dataset
-dataset = load_dataset(
-    'parquet',
-    data_files='/workspace/data/Synthetic-Visual-Correspondence-Data/parquet_data/samples_*.parquet',
-    features=features
-)["train"]
-
-image_folder = "/workspace/data/synthetic_visualcorres/images"
-os.makedirs(image_folder, exist_ok=True)
+DATA_FILES = (
+    "hf://datasets/mavleo96/"
+    "Synthetic-Visual-Correspondence-Data/parquet_data/samples_*.parquet"
+)
 
 
-image_prompt = f"Image 1: {DEFAULT_IMAGE_TOKEN}\n Image 2: {DEFAULT_IMAGE_TOKEN}\n "
-question_text = "Question: Which point is corresponding to the reference point?"
-detailed_prompt = "Details: A point is circled on the first image, labeled with REF. We change the camera position or lighting and shoot the second image. You are given multiple red-circled points on the second image, choices of \"A, B, C, D\" are drawn beside each circle. Which point on the second image corresponds to the point in the first image? Select from the following options.\n(A) Point A\n(B) Point B\n(C) Point C\n(D) Point D"
-directive = "Answer with the option’s letter from the given choices directly."
+def main():
+    parser = argparse.ArgumentParser(description="Convert synthetic visual correspondence parquet data to LLaVA JSON.")
+    parser.add_argument(
+        "--image_folder",
+        type=str,
+        default="/workspace/data/synthetic_visualcorres/images",
+        help="Folder to save JPEG images for the synthetic visual correspondence dataset.",
+    )
+    args = parser.parse_args()
 
-converted_data = []
-for da in tqdm(dataset):
-    json_data = {}
-    json_data["id"] = da["id"]
+    # Load dataset (same parquet shards as the vision-encoder eval script).
+    dataset = load_dataset("parquet", data_files=DATA_FILES, split="train")
 
-    # Save images
-    stem, _ = os.path.splitext(da["id"])
-    out_path_1 = os.path.join(image_folder, f"{stem}_1.jpg")
-    out_path_2 = os.path.join(image_folder, f"{stem}_2.jpg")
-    img_1 = da["image_1"]
-    img_2 = da["image_2"]
-    if img_1.mode != "RGB":
-        img_1 = img_1.convert("RGB")
-    img_1.save(out_path_1, format="JPEG")
-    if img_2.mode != "RGB":
-        img_2 = img_2.convert("RGB")
-    img_2.save(out_path_2, format="JPEG")
-    json_data["image"] = [out_path_1, out_path_2]
+    image_folder = args.image_folder
+    os.makedirs(image_folder, exist_ok=True)
 
-    # Save conversations
-    json_data["conversations"] = [
-        {"from": "human", "value": image_prompt + "\n" + question_text + "\n" + detailed_prompt + "\n" + directive},
-        {"from": "gpt", "value": f"({da['ref_label']})"}
-    ]
+    image_prompt = f"Image 1: {DEFAULT_IMAGE_TOKEN}\n Image 2: {DEFAULT_IMAGE_TOKEN}\n "
+    question_text = "Question: Which point is corresponding to the reference point?"
+    detailed_prompt = (
+        "Details: A point is circled on the first image, labeled with REF. We change the camera position or "
+        "lighting and shoot the second image. You are given multiple red-circled points on the second image, "
+        'choices of "A, B, C, D" are drawn beside each circle. Which point on the second image corresponds to '
+        "the point in the first image? Select from the following options.\n(A) Point A\n(B) Point B\n(C) Point C\n(D) Point D"
+    )
+    directive = "Answer with the option’s letter from the given choices directly."
 
-    # Save data
-    converted_data.append(json_data)
+    converted_data = []
+    for da in tqdm(dataset):
+        json_data = {}
+        json_data["id"] = da["id"]
 
-with open(os.path.join(os.path.dirname(image_folder), "synthetic_visualcorres_data.json"), "w") as f:
-    json.dump(converted_data, f, indent=4, ensure_ascii=False)
+        # Save images
+        stem, _ = os.path.splitext(da["id"])
+        out_path_1 = os.path.join(image_folder, f"{stem}_1.jpg")
+        out_path_2 = os.path.join(image_folder, f"{stem}_2.jpg")
+        img_1 = da["image_1"]
+        img_2 = da["image_2"]
+        if img_1.mode != "RGB":
+            img_1 = img_1.convert("RGB")
+        img_1.save(out_path_1, format="JPEG")
+        if img_2.mode != "RGB":
+            img_2 = img_2.convert("RGB")
+        img_2.save(out_path_2, format="JPEG")
+        json_data["image"] = [out_path_1, out_path_2]
+
+        # Save conversations
+        json_data["conversations"] = [
+            {
+                "from": "human",
+                "value": image_prompt + "\n" + question_text + "\n" + detailed_prompt + "\n" + directive,
+            },
+            {"from": "gpt", "value": f"({da['ref_label']})"},
+        ]
+
+        # Save data
+        converted_data.append(json_data)
+
+    with open(os.path.join(os.path.dirname(image_folder), "synthetic_visualcorres_data.json"), "w") as f:
+        json.dump(converted_data, f, indent=4, ensure_ascii=False)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/fix_data_json.py
+++ b/scripts/fix_data_json.py
@@ -1,5 +1,16 @@
+"""Add missing <image> tokens to the first human turn in LLaVA-style JSON.
+
+Given a JSON file containing a list of records with a `conversations` field, this script:
+  1) Loads the JSON file from `--json_path`.
+  2) For each record, checks the first conversation turn (`conversations[0]["value"]`).
+  3) If the string does not already contain `<image>`, it prepends `<image>\\n`.
+The modified JSON overwrites the input file in place and the script reports how many
+records were changed.
+"""
+
 import json
 import argparse
+
 
 def main():
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
Enhance synthetic visual correspondence data processing script to convert parquet shards into LLaVA-style JSON and JPEGs. Introduce command-line argument for image folder path and improve dataset loading. Update image saving logic and conversation formatting for better integration with LLaVA. Additionally, add documentation for clarity.